### PR TITLE
Improved exclusion counting

### DIFF
--- a/analysis/exclusion_counts.py
+++ b/analysis/exclusion_counts.py
@@ -46,4 +46,4 @@ for r in df.groupby('budesonide_prescription')['patient_id'].count().reset_index
     out_dict[f'has_budesonide_prescription__{r[1].budesonide_prescription}'] = r[1].patient_id
 
 with open('output/exclusioncounts.txt', 'w+') as wf:
-    wf.writelines([f'{k}:{v if v>10 else '<10'}\n' for k, v in out_dict.items()])
+    wf.writelines([f'{k}:{v if v>10 else "<10"}' for k,v in out_dict.items()])

--- a/analysis/study_definition_exclusioncounts.py
+++ b/analysis/study_definition_exclusioncounts.py
@@ -66,7 +66,7 @@ study = StudyDefinition(
         test_result="positive",
         on_or_after=ix_dt,
         find_first_match_in_period=True,
-        restrict_to_earliest_specimen_date=False,
+        #restrict_to_earliest_specimen_date=False,
         returning="date",
         date_format="YYYY-MM-DD",
         return_expectations={
@@ -80,7 +80,7 @@ study = StudyDefinition(
         test_result="positive",
         on_or_after=ix_dt,
         find_first_match_in_period=True,
-        restrict_to_earliest_specimen_date=False,
+        #restrict_to_earliest_specimen_date=False,
         returning="case_category",
         return_expectations={
             "rate":"universal",


### PR DESCRIPTION
- calculate age on basis of index date as not to pre-exclude on the basis of +ve PCR
- ~~remove SGSS restriction to first sample~~ not possible to get case_category with this, reverted
- add additional exclusion counting steps
- built-in <10 count suppression