### PR TITLE
revise admissions, count inputs

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -46,3 +46,9 @@ primis_nonshield = codelist_from_csv(
     system="snomed",
     column="code"
 )
+#from https://github.com/opensafely/vaccine-effectiveness-hospital-admissions-validation/
+covid_codes_ae = codelist_from_csv(
+    "analysis/covid_codes_ae.csv",
+    system="snomed",
+    column="snomed_id",
+)

--- a/analysis/covid_codes_ae.csv
+++ b/analysis/covid_codes_ae.csv
@@ -1,0 +1,3 @@
+snomed_id,description
+1240751000000100,Coronavirus disease 19 caused by severe acute respiratory syndrome coronavirus 2 (disorder) [ND]
+840539006, Disease caused by severe acute respiratory syndrome coronavirus 2 [International SNOMED code]

--- a/analysis/exclusion_counts.py
+++ b/analysis/exclusion_counts.py
@@ -1,26 +1,29 @@
 import pandas as pd
 import os
-
-#     """
-#         NOT has_died
-#         AND
-#         registered
-#         AND
-#         (age >= 65 OR ((age >=55 AND age <65) AND has_comorbidities))
-#         AND
-#         (sex = "M" OR sex = "F")
-#         AND
-#         (first_positive_test_type = "PCR_Only" OR first_positive_test_type = "LFT_WithPCR")
-
-#         AND
-#         NOT has_previous_steroid_prescription
-#     """,
-
 df = pd.read_csv('output/input_exclusioncounts.csv')
 
 out_dict = {}
 
 out_dict['totalrows'] = len(df.index)
+
+df.covid_admission = df.covid_admission.fillna(0)
+for r in df.groupby('covid_admission')['patient_id'].count().reset_index().iterrows():
+    out_dict[f'initial_covid_emergency_admission__{r[1].covid_admission}'] = r[1].patient_id
+
+df.primary_covid_hospital_admission = df.primary_covid_hospital_admission.fillna(
+    0)
+for r in df.groupby('primary_covid_hospital_admission')['patient_id'].count().reset_index().iterrows():
+    out_dict[f'initial_primary_covid_hospital_admission__{r[1].primary_covid_hospital_admission}'] = r[1].patient_id
+
+df.covid_emergency_admission = df.covid_emergency_admission.fillna(0)
+for r in df.groupby('covid_emergency_admission')['patient_id'].count().reset_index().iterrows():
+    out_dict[f'initial_covid_emergency_admission__{r[1].covid_emergency_admission}'] = r[1].patient_id
+
+df.has_previous_steroid_prescription = df.has_previous_steroid_prescription.fillna(
+    0)
+out_dict['initial_NOT_has_previous_steroid_prescription'] = len(
+    df[df.has_previous_steroid_prescription == 0].index)
+
 df = df[df.has_died == 0]
 out_dict['has_not_died'] = len(df.index)
 
@@ -28,15 +31,13 @@ df = df[df.registered == 1]
 out_dict['registered'] = len(df.index)
 
 out_dict['over_65'] = len(df[df.age >= 65].index)
-# out_dict['over_55_comorbidities'] = len(
-#     df[((df.age < 65) & (df.age >= 55)) & (df.has_comorbidities == 1)].index)
-# df = df[(df.age >= 65) | (((df.age < 65) & (df.age >= 55))
-#                           & (df.has_comorbidities == 1))]
-#out_dict['over_55_no_covid_risk'] = len(df[((df.age < 65) & (df.age >= 55))   & (df.primis_shield == 0)& (df.primis_nonshield == 0)].index)
-out_dict['over_55_low_covid_risk'] = len(df[((df.age < 65) & (df.age >= 55))  & (df.primis_shield == 0)& (df.primis_nonshield == 1)].index)
-out_dict['over_55_high_covid_risk'] = len(df[((df.age < 65) & (df.age >= 55)) & (df.primis_shield == 1)].index)
+out_dict['over_55_low_covid_risk'] = len(df[((df.age < 65) & (df.age >= 55)) & (
+    df.primis_shield == 0) & (df.primis_nonshield == 1)].index)
+out_dict['over_55_high_covid_risk'] = len(
+    df[((df.age < 65) & (df.age >= 55)) & (df.primis_shield == 1)].index)
 
 df.drop((df[((df.age < 65) & (df.age >= 55)) & (df.primis_shield == 1)].index))
+df.drop(df[df.age < 55].index)
 
 df = df[(df.sex == 'M') | (df.sex == 'F')]
 out_dict['sex_M_or_F'] = len(df.index)
@@ -45,23 +46,28 @@ out_dict['sex_M_or_F'] = len(df.index)
 df = df[df.first_positive_test_date.notna()]
 out_dict['first_positive_test_date_notna'] = len(df.index)
 
-df.first_positive_test_type=df.first_positive_test_type.fillna('NA')
+df.first_positive_test_type = df.first_positive_test_type.fillna('NA')
 for r in df.groupby('first_positive_test_type')['patient_id'].count().reset_index().iterrows():
     out_dict[f'first_positive_test_type__{r[1].first_positive_test_type}'] = r[1].patient_id
 
-out_dict['+ve_over_65'] = len(df[df.age >= 65].index)
-#out_dict['+ve_over_55_no_covid_risk'] = len(df[((df.age < 65) & (df.age >= 55))   & (df.primis_shield == 0)& (df.primis_nonshield == 0)].index)
-out_dict['+ve_over_55_low_covid_risk'] = len(df[((df.age < 65) & (df.age >= 55))  & (df.primis_shield == 0)& (df.primis_nonshield == 1)].index)
-out_dict['+ve_over_55_high_covid_risk'] = len(df[((df.age < 65) & (df.age >= 55)) & (df.primis_shield == 1)].index)
+df = df[df.first_positive_test_type != "LFT_Only"]
 
-df.has_previous_steroid_prescription = df.has_previous_steroid_prescription.fillna(0)
-df = df[df.has_previous_steroid_prescription==0]
+out_dict['PCR_+ve_over_65'] = len(df[df.age >= 65].index)
+out_dict['PCR_+ve_over_55_low_covid_risk'] = len(df[((df.age < 65) & (
+    df.age >= 55)) & (df.primis_shield == 0) & (df.primis_nonshield == 1)].index)
+out_dict['PCR_+ve_over_55_high_covid_risk'] = len(
+    df[((df.age < 65) & (df.age >= 55)) & (df.primis_shield == 1)].index)
+
+df.has_previous_steroid_prescription = df.has_previous_steroid_prescription.fillna(
+    0)
+df = df[df.has_previous_steroid_prescription == 0]
 out_dict['NOT_has_previous_steroid_prescription'] = len(df.index)
 
-df.covid_admission= df.covid_admission.fillna(0)
+df.covid_admission = df.covid_admission.fillna(0)
 df.covid_emergency_admission = df.covid_emergency_admission.fillna(0)
 
-df[(df.covid_admission == 0) & (df.covid_emergency_admission == 0)]
+df[(df.covid_admission == 0) & (df.primary_covid_hospital_admission == 0)
+    & (df.covid_emergency_admission == 0)]
 out_dict['NOT_hospitalised'] = len(df.index)
 
 out_dict['with_consultation'] = len(df[df.with_consultation == 1].index)
@@ -70,4 +76,5 @@ for r in df.groupby('budesonide_prescription')['patient_id'].count().reset_index
     out_dict[f'has_budesonide_prescription__{r[1].budesonide_prescription}'] = r[1].patient_id
 
 with open('output/exclusioncounts.txt', 'w+') as wf:
-    wf.writelines([f'{k}:{v if v>10 else "<10"}\n' for k,v in out_dict.items()])
+    wf.writelines(
+        [f'{k}:{v if v>10 else "<10"}\n' for k, v in out_dict.items()])

--- a/analysis/study_definition_exclusioncounts.py
+++ b/analysis/study_definition_exclusioncounts.py
@@ -71,7 +71,7 @@ study = StudyDefinition(
             "rate" : "exponential_increase"
         },
     ),
-    
+
     first_positive_test_type=patients.with_test_result_in_sgss(
         pathogen="SARS-CoV-2",
         test_result="positive",
@@ -219,13 +219,23 @@ study = StudyDefinition(
 
         covid_emergency_admission_date=patients.attended_emergency_care(
             returning= "date_arrived",
-            with_these_diagnoses=covid_codelist,
+            with_these_diagnoses=covid_codes_ae,
             on_or_after="first_positive_test_date",
             find_first_match_in_period=True,
             date_format="YYYY-MM-DD",
         ),
     ),
-    
+
+    primary_covid_hospital_admission=patients.admitted_to_hospital(
+        returning= "binary_flag",
+        with_these_primary_diagnoses=covid_codelist,
+        on_or_after="first_positive_test_date",
+        find_last_match_in_period=True,
+        return_expectations={
+            "incidence": 0.3,
+        },
+    ),
+
     covid_admission=patients.admitted_to_hospital(
         returning= "binary_flag",
         with_these_diagnoses=covid_codelist,
@@ -234,7 +244,7 @@ study = StudyDefinition(
 
     covid_emergency_admission=patients.attended_emergency_care(
         returning= "binary_flag",
-        with_these_diagnoses=covid_codelist,
+        with_these_diagnoses=covid_codes_ae,
         on_or_after="first_positive_test_date",
         return_expectations = {"incidence": 0.05}),
     


### PR DESCRIPTION
- use snomed-ct codes for a&e admission, not icd10
  - from from https://github.com/opensafely/vaccine-effectiveness-hospital-admissions-validation/
- add variable for hosp admission with *primary* diagnosis of covid codes
- add initial counts of values for all hospitalisation-related variables
- update exclusion count to include primary diagnosis admission var